### PR TITLE
Add Flask AI dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# codex-Project1
+# AI Dashboard App
+
+This project is a simple Flask-based dashboard that aggregates information related to Artificial Intelligence:
+
+- Top AI news stories from Hacker News
+- Popular open-source AI repositories on GitHub
+- Trending HuggingFace models
+- Recently submitted AI papers on arXiv
+- Most viewed AI videos on YouTube (requires a YouTube API key)
+
+## Running locally
+
+```bash
+pip install -r requirements.txt
+export YOUTUBE_API_KEY=YOUR_KEY  # optional
+python app.py
+```
+
+Visit `http://localhost:8000` in your browser.
+
+## Deploying
+
+You can deploy this application to [Vercel](https://vercel.com/) easily:
+
+1. Install the Vercel CLI:
+   ```bash
+   npm install -g vercel
+   ```
+2. Run `vercel` and follow the prompts to deploy.
+3. Set the `YOUTUBE_API_KEY` environment variable in your Vercel dashboard if you want video data.
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,120 @@
+import os
+import requests
+from flask import Flask, render_template
+import xml.etree.ElementTree as ET
+
+app = Flask(__name__)
+
+HNEWS_URL = "https://hn.algolia.com/api/v1/search"
+GITHUB_URL = "https://api.github.com/search/repositories"
+HFACE_URL = "https://huggingface.co/api/models"
+ARXIV_URL = "https://export.arxiv.org/api/query"
+YOUTUBE_SEARCH_URL = "https://www.googleapis.com/youtube/v3/search"
+
+
+def fetch_hn_news():
+    params = {
+        "query": "AI",
+        "tags": "story",
+        "hitsPerPage": 5,
+    }
+    try:
+        r = requests.get(HNEWS_URL, params=params, timeout=10)
+        r.raise_for_status()
+        return r.json().get("hits", [])
+    except Exception:
+        return []
+
+
+def fetch_github_repos():
+    params = {
+        "q": "topic:ai",
+        "order": "desc",
+        "per_page": 5,
+    }
+    try:
+        r = requests.get(GITHUB_URL, params=params, timeout=10)
+        r.raise_for_status()
+        return r.json().get("items", [])
+    except Exception:
+        return []
+
+
+def fetch_huggingface_models():
+    try:
+        r = requests.get(HFACE_URL, params=params, timeout=10)
+        r.raise_for_status()
+        return r.json()
+    except Exception:
+        return []
+
+
+def fetch_arxiv_papers():
+    params = {
+        "search_query": "all:artificial intelligence",
+        "start": 0,
+        "max_results": 5,
+        "sortBy": "submittedDate",
+        "sortOrder": "descending",
+    }
+    try:
+        r = requests.get(ARXIV_URL, params=params, timeout=10)
+        r.raise_for_status()
+        root = ET.fromstring(r.text)
+        ns = {"atom": "http://www.w3.org/2005/Atom"}
+        entries = []
+        for entry in root.findall("atom:entry", ns):
+            title = entry.find("atom:title", ns).text
+            link = entry.find("atom:link", ns).attrib.get("href")
+            entries.append({"title": title, "url": link})
+        return entries
+    except Exception:
+        return []
+
+
+def fetch_youtube_videos():
+    api_key = os.environ.get("YOUTUBE_API_KEY")
+    if not api_key:
+        return []
+    params = {
+        "part": "snippet",
+        "q": "AI",
+        "type": "video",
+        "order": "viewCount",
+        "maxResults": 5,
+        "key": api_key,
+    }
+    try:
+        r = requests.get(YOUTUBE_SEARCH_URL, params=params, timeout=10)
+        r.raise_for_status()
+        items = r.json().get("items", [])
+        results = []
+        for item in items:
+            video_id = item["id"]["videoId"]
+            title = item["snippet"]["title"]
+            url = f"https://www.youtube.com/watch?v={video_id}"
+            results.append({"title": title, "url": url})
+        return results
+    except Exception:
+        return []
+
+
+@app.route("/")
+def index():
+    news = fetch_hn_news()
+    repos = fetch_github_repos()
+    models = fetch_huggingface_models()
+    papers = fetch_arxiv_papers()
+    videos = fetch_youtube_videos()
+    return render_template(
+        "index.html",
+        news=news,
+        repos=repos,
+        models=models,
+        papers=papers,
+        videos=videos,
+    )
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+flask
+requests

--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,38 @@
+body {
+    font-family: Arial, sans-serif;
+    background: #f2f2f7;
+    margin: 0;
+}
+nav {
+    background: #002b36;
+    color: #fff;
+    padding: 1rem;
+}
+main {
+    padding: 1rem 2rem;
+}
+section {
+    margin-bottom: 2rem;
+    background: #fff;
+    padding: 1rem;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+section h2 {
+    margin-top: 0;
+    color: #073642;
+}
+ul {
+    list-style: none;
+    padding-left: 0;
+}
+li {
+    margin-bottom: 0.5rem;
+}
+a {
+    color: #268bd2;
+    text-decoration: none;
+}
+a:hover {
+    text-decoration: underline;
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>AI Dashboard</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body>
+    <nav>
+        <h1>AI Dashboard</h1>
+    </nav>
+    <main>
+        <section>
+            <h2>Top AI News</h2>
+            <ul>
+                {% for item in news %}
+                <li><a href="{{ item.url }}" target="_blank">{{ item.title }}</a></li>
+                {% else %}
+                <li>No data</li>
+                {% endfor %}
+            </ul>
+        </section>
+        <section>
+            <h2>Popular GitHub AI Repos</h2>
+            <ul>
+                {% for repo in repos %}
+                <li><a href="{{ repo.html_url }}" target="_blank">{{ repo.full_name }}</a></li>
+                {% else %}
+                <li>No data</li>
+                {% endfor %}
+            </ul>
+        </section>
+        <section>
+            <h2>Top HuggingFace Models</h2>
+            <ul>
+                {% for m in models %}
+                <li><a href="https://huggingface.co/{{ m.id }}" target="_blank">{{ m.id }}</a></li>
+                {% else %}
+                <li>No data</li>
+                {% endfor %}
+            </ul>
+        </section>
+        <section>
+            <h2>Latest AI Papers</h2>
+            <ul>
+                {% for p in papers %}
+                <li><a href="{{ p.url }}" target="_blank">{{ p.title }}</a></li>
+                {% else %}
+                <li>No data</li>
+                {% endfor %}
+            </ul>
+        </section>
+        <section>
+            <h2>Popular AI Videos</h2>
+            <ul>
+                {% for v in videos %}
+                <li><a href="{{ v.url }}" target="_blank">{{ v.title }}</a></li>
+                {% else %}
+                <li>Set YOUTUBE_API_KEY to enable video data.</li>
+                {% endfor %}
+            </ul>
+        </section>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create a Flask app to show AI news, GitHub repos, HuggingFace models, arXiv papers and YouTube videos
- add HTML template and CSS styling
- document how to run and deploy with Vercel
- add Python requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688c82818d60832f997aaec562b95272